### PR TITLE
升级jsqlparser 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <dependency>
             <groupId>com.github.jsqlparser</groupId>
             <artifactId>jsqlparser</artifactId>
-            <version>3.2</version>
+            <version>4.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jetlinks/reactor/ql/feature/FilterFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/feature/FilterFeature.java
@@ -165,6 +165,16 @@ public interface FilterFeature extends Feature {
             }
 
             @Override
+            public void visit(VariableAssignment aThis) {
+
+            }
+
+            @Override
+            public void visit(XMLSerializeExpr aThis) {
+
+            }
+
+            @Override
             public void visit(NullValue value) {
                 ref.set((row, column) -> Mono.just(column == null));
             }

--- a/src/main/java/org/jetlinks/reactor/ql/feature/ValueFlatMapFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/feature/ValueFlatMapFeature.java
@@ -1,6 +1,8 @@
 package org.jetlinks.reactor.ql.feature;
 
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.VariableAssignment;
+import net.sf.jsqlparser.expression.XMLSerializeExpr;
 import org.jetlinks.reactor.ql.ReactorQLMetadata;
 import org.jetlinks.reactor.ql.ReactorQLRecord;
 import reactor.core.publisher.Flux;
@@ -26,6 +28,16 @@ public interface ValueFlatMapFeature extends Feature {
             public void visit(net.sf.jsqlparser.expression.Function function) {
                 metadata.getFeature(FeatureId.ValueFlatMap.of(function.getName()))
                         .ifPresent(feature -> ref.set(feature.createMapper(function, metadata)));
+            }
+
+            @Override
+            public void visit(VariableAssignment aThis) {
+
+            }
+
+            @Override
+            public void visit(XMLSerializeExpr aThis) {
+
             }
         });
 

--- a/src/main/java/org/jetlinks/reactor/ql/feature/ValueMapFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/feature/ValueMapFeature.java
@@ -78,6 +78,16 @@ public interface ValueMapFeature extends Feature {
             }
 
             @Override
+            public void visit(VariableAssignment aThis) {
+
+            }
+
+            @Override
+            public void visit(XMLSerializeExpr aThis) {
+
+            }
+
+            @Override
             public void visit(Parenthesis value) {
                 createMapperByExpression(value.getExpression(), metadata).ifPresent(ref::set);
             }

--- a/src/main/java/org/jetlinks/reactor/ql/utils/ExpressionUtils.java
+++ b/src/main/java/org/jetlinks/reactor/ql/utils/ExpressionUtils.java
@@ -62,6 +62,16 @@ public class ExpressionUtils {
                 ref.set(function.getValue());
             }
 
+            @Override
+            public void visit(VariableAssignment aThis) {
+                
+            }
+
+            @Override
+            public void visit(XMLSerializeExpr aThis) {
+
+            }
+
         });
 
         return Optional.ofNullable(ref.get());

--- a/src/test/java/org/jetlinks/reactor/ql/ReactorQLTest.java
+++ b/src/test/java/org/jetlinks/reactor/ql/ReactorQLTest.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 class ReactorQLTest {
 
@@ -1397,6 +1396,38 @@ class ReactorQLTest {
                  .as(StepVerifier::create)
                  .expectNext(3)
                  .verifyComplete();
+    }
+
+    @Test
+    void testFiledExtract() {
+        String sql = "select deviceNum,this.payload.current.gpsSpeed as gpsSpeed from dual where this.payload.current.gpsSpeed>22";
+
+        ReactorQL.builder()
+                .sql(sql)
+                .build()
+                .start(Flux.just(new HashMap<String, Object>() {
+                    {
+                        put("deviceNum", "12131221");
+                        put("payload", new HashMap<String, Object>() {
+                                    {
+                                        put("previous", new HashMap<String, Object>() {{
+                                            put("gpsSpeed", 22.3);
+                                            put("oilTemperature", 34.5);
+                                        }});
+                                        put("current", new HashMap<String, Object>() {{
+                                            put("gpsSpeed", 34.3);
+                                            put("oilTemperature", 45.5);
+                                        }});
+                                    }
+                                }
+                        );
+                    }
+                }))
+                .doOnNext(System.out::println)
+                .map(map -> map.get("gpsSpeed"))
+                .as(StepVerifier::create)
+                .expectNext(34.3)
+                .verifyComplete();
     }
 
 }


### PR DESCRIPTION
{
  "eventType":"TelemetryPost"
  "topic": "Telemetry/device/version/function/event/xxx",
  "deviceNum": "12131221",
  "recordTime": 1621238178609
  "payload":{
    "previous": {
      "gpsSpeed":22.3,
      "oilTemperature":34.5
    },
    "current":{
      "gpsSpeed":34.3,
      "oilTemperature":43.5
    }
  }
}


当 SQL 为 
```
select deviceNum,recordTime,this.payload.current.gpsSpeed as gpsSpeed " +
                "from \"telmetry/*/*/*/event/**\" where this.payload.current.gpsSpeed>22
```
时jsqlparser 3.2 报错 升级到4.0后是可以的. 在本地运行了单元测试`ReactorQLTest` 是没有问题的