### PR TITLE
build: 升级依赖版本

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <project.build.locales>zh_CN</project.build.locales>
         <java.version>1.8</java.version>
         <project.build.jdk>${java.version}</project.build.jdk>
-        <reactor.version>Dysprosium-SR10</reactor.version>
+        <reactor.version>2020.0.36</reactor.version>
     </properties>
 
     <profiles>
@@ -235,7 +235,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.36</version>
         </dependency>
 
         <dependency>
@@ -257,16 +257,17 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.12</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.jetlinks</groupId>
     <artifactId>reactor-ql</artifactId>
-    <version>1.0.16</version>
+    <version>1.0.17-SNAPSHOT</version>
 
     <name>JetLinks</name>
     <url>https://github.com/jetlinks/reactor-ql</url>
@@ -277,7 +277,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.1.2-jre</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
升级guava到32.1.2-jre
升级slf4j到1.7.36
升级logback到1.2.12
升级lombok到1.18.30
升级reactor到2020.0.36