### PR TITLE
fix(基础模块): 修复new_map函数的空值处理

### DIFF
--- a/src/main/java/org/jetlinks/reactor/ql/supports/DefaultReactorQLMetadata.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/DefaultReactorQLMetadata.java
@@ -404,9 +404,10 @@ public class DefaultReactorQLMetadata implements ReactorQLMetadata {
         addGlobal(new FunctionMapFeature("new_array", 9999, 1, stream -> stream.collect(Collectors.toList())));
 
         //select new_map('k1',v1,'k2',v2);
-        addGlobal(new FunctionMapFeature("new_map", 9999, 1, stream ->
-                stream.collectList()
-                      .map(CastUtils::castMap)));
+        addGlobal(new FunctionMapFeature("new_map", 9999, 1, stream -> stream
+                .collectList()
+                .map(CastUtils::castMap))
+                          .defaultValue(""));
 
 
         // addGlobal(new BinaryMapFeature("concat", concat));

--- a/src/main/java/org/jetlinks/reactor/ql/supports/DefaultReactorQLMetadata.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/DefaultReactorQLMetadata.java
@@ -47,7 +47,7 @@ public class DefaultReactorQLMetadata implements ReactorQLMetadata {
 
     private Map<String, Object> settings = null;
 
-    private static final String MAP_NULL_VALUE = "new_map_null";
+    private static final DefaultMapNullValue MAP_NULL_VALUE = new DefaultMapNullValue();
 
     static <T> void createCalculator(BiFunction<String, BiFunction<Number, Number, Object>, T> builder, Consumer<T> consumer) {
 
@@ -655,5 +655,8 @@ public class DefaultReactorQLMetadata implements ReactorQLMetadata {
     @Override
     public Collection<Feature> getFeatures() {
         return features == null ? Collections.emptyList() : features.values();
+    }
+
+    static class DefaultMapNullValue {
     }
 }

--- a/src/main/java/org/jetlinks/reactor/ql/supports/DefaultReactorQLMetadata.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/DefaultReactorQLMetadata.java
@@ -47,7 +47,7 @@ public class DefaultReactorQLMetadata implements ReactorQLMetadata {
 
     private Map<String, Object> settings = null;
 
-    private static final DefaultMapNullValue MAP_NULL_VALUE = new DefaultMapNullValue();
+    private static final Object MAP_NULL_VALUE = new Object();
 
     static <T> void createCalculator(BiFunction<String, BiFunction<Number, Number, Object>, T> builder, Consumer<T> consumer) {
 
@@ -655,8 +655,5 @@ public class DefaultReactorQLMetadata implements ReactorQLMetadata {
     @Override
     public Collection<Feature> getFeatures() {
         return features == null ? Collections.emptyList() : features.values();
-    }
-
-    static class DefaultMapNullValue {
     }
 }

--- a/src/main/java/org/jetlinks/reactor/ql/supports/DefaultReactorQLMetadata.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/DefaultReactorQLMetadata.java
@@ -47,6 +47,8 @@ public class DefaultReactorQLMetadata implements ReactorQLMetadata {
 
     private Map<String, Object> settings = null;
 
+    private static final String MAP_NULL_VALUE = "new_map_null";
+
     static <T> void createCalculator(BiFunction<String, BiFunction<Number, Number, Object>, T> builder, Consumer<T> consumer) {
 
         consumer.accept(builder.apply("+", CalculateUtils::add));
@@ -406,8 +408,11 @@ public class DefaultReactorQLMetadata implements ReactorQLMetadata {
         //select new_map('k1',v1,'k2',v2);
         addGlobal(new FunctionMapFeature("new_map", 9999, 1, stream -> stream
                 .collectList()
-                .map(CastUtils::castMap))
-                          .defaultValue(""));
+                .map(list -> CastUtils
+                        .castMap(list,
+                                 Function.identity(),
+                                 value -> MAP_NULL_VALUE.equals(value) ? null : value)))
+                          .defaultValue(MAP_NULL_VALUE));
 
 
         // addGlobal(new BinaryMapFeature("concat", concat));


### PR DESCRIPTION
错误原因：(key,value...)中存在空值时，顺序会错乱。已添加默认空字符串