### PR TITLE
refactor: 升级 JSqlParser 5.3 并补充兼容覆盖

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,11 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: temurin
+          java-version: 11
+          cache: maven
       - name: Cache Maven Repository
         uses: actions/cache@v3
         with:
@@ -23,7 +25,7 @@ jobs:
       - name: Build with Maven
         run: ./mvnw test
       - name: Codecov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v4
         with:
           # Repository upload token - get it from codecov.io. Required only for private repositories
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -12,13 +12,14 @@ jobs:
         #        os: [ubuntu-latest, windows-latest, macOS-latest]
         os: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - run: echo ${{github.ref}}
       - name: Set up Repository info
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: '11'
+          distribution: temurin
+          cache: maven
       - name: Cache Maven Repository
         uses: actions/cache@v3
         with:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,7 +1,7 @@
 name: Auto Deploy reactor-ql to the JetLinks Maven Repository
 on:
   push:
-    branches: ["master"]
+    branches: ["master","1.1"]
 
 jobs:
   publish:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,11 +7,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: temurin
+          java-version: 11
+          cache: maven
       - name: Cache Maven Repository
         uses: actions/cache@v3
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+ignore:
+  - "pom.xml"
+  - ".github/**/*"
+  - "src/main/java/org/jetlinks/reactor/ql/supports/ExpressionVisitorAdapter.java"
+
+github_checks:
+  annotations: false

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.jetlinks</groupId>
     <artifactId>reactor-ql</artifactId>
-    <version>1.0.21-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>JetLinks</name>
     <url>https://github.com/jetlinks/reactor-ql</url>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.locales>zh_CN</project.build.locales>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <project.build.jdk>${java.version}</project.build.jdk>
         <reactor.version>2020.0.38</reactor.version>
     </properties>
@@ -205,6 +205,7 @@
                     <excludes>
                         <exclude>**/ExpressionVisitorAdapter*</exclude>
                         <exclude>**/ReactorQLMetadata*</exclude>
+                        <exclude>net/sf/jsqlparser/**</exclude>
                     </excludes>
                 </configuration>
                 <executions>
@@ -253,10 +254,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.11.0</version>
                 <configuration>
-                    <source>${project.build.jdk}</source>
-                    <target>${project.build.jdk}</target>
+                    <release>${project.build.jdk}</release>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
@@ -288,7 +288,7 @@
         <dependency>
             <groupId>com.github.jsqlparser</groupId>
             <artifactId>jsqlparser</artifactId>
-            <version>4.6</version>
+            <version>5.3</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jetlinks/reactor/ql/DefaultReactorQL.java
+++ b/src/main/java/org/jetlinks/reactor/ql/DefaultReactorQL.java
@@ -185,12 +185,12 @@ public class DefaultReactorQL implements ReactorQL {
             Function<ReactorQLRecord, Flux<ReactorQLRecord>> rightStreamGetter = null;
 
             //join (select deviceId,avg(temp) from temp group by interval('10s'),deviceId )
-            if (from instanceof SubSelect) {
+            if (from instanceof ParenthesedSelect) {
                 String alias = from.getAlias() == null ? null : from.getAlias().getName();
                 //子查询
                 DefaultReactorQL ql =
                         new DefaultReactorQL(new DefaultReactorQLMetadata(metadata,
-                                                                          ((PlainSelect) ((SubSelect) from).getSelectBody())));
+                                                                          ((PlainSelect) ((ParenthesedSelect) from).getSelect().getPlainSelect())));
 
                 rightStreamGetter = record -> ql
                         .builder
@@ -301,7 +301,8 @@ public class DefaultReactorQL implements ReactorQL {
                     groupByRef.set(nameMapper);
                 }
             };
-            for (Expression groupByExpression : groupBy.getGroupByExpressionList().getExpressions()) {
+            for (Object expression : groupBy.getGroupByExpressionList().getExpressions()) {
+                Expression groupByExpression = (Expression) expression;
                 //函数分组, group by interval('1s')
                 if (groupByExpression instanceof net.sf.jsqlparser.expression.Function) {
                     featureConsumer.accept(null,
@@ -404,54 +405,42 @@ public class DefaultReactorQL implements ReactorQL {
 
         List<Consumer<ReactorQLRecord>> allMapper = new ArrayList<>();
 
-        for (SelectItem selectItem : metadata.getSql().getSelectItems()) {
-            selectItem.accept(new SelectItemVisitorAdapter() {
-                // select a,b,c
-                @Override
-                public void visit(SelectExpressionItem item) {
-                    Expression expression = item.getExpression();
-                    String alias = item.getAlias() == null ? expression.toString() : item.getAlias().getName();
-                    String fAlias = SqlUtils.getCleanStr(alias);
-                    // select a,b,c
-                    createExpressionMapper(expression).ifPresent(mapper -> mappers.put(fAlias, mapper));
-                    // select count(),max(val)...
-                    createAggMapper(expression).ifPresent(mapper -> aggMapper.put(fAlias, mapper));
-                    //flatMap
-                    ValueFlatMapFeature.createMapperByExpression(expression, metadata)
-                                       .ifPresent(mapper -> flatMappers.put(fAlias, mapper));
-
-                    if (!mappers.containsKey(fAlias) && !aggMapper.containsKey(fAlias) && !flatMappers.containsKey(fAlias)) {
-                        throw new UnsupportedOperationException("Unsupported expression:" + expression);
-                    }
+        for (SelectItem<?> selectItem : metadata.getSql().getSelectItems()) {
+            Expression expression = selectItem.getExpression();
+            if (expression instanceof AllColumns) {
+                allMapper.add(ReactorQLRecord::putRecordToResult);
+                continue;
+            }
+            if (expression instanceof AllTableColumns) {
+                AllTableColumns columns = (AllTableColumns) expression;
+                String name;
+                Alias alias = columns.getTable().getAlias();
+                if (alias == null) {
+                    name = SqlUtils.getCleanStr(columns.getTable().getName());
+                } else {
+                    name = SqlUtils.getCleanStr(alias.getName());
                 }
+                allMapper.add(record -> record
+                        .getRecord(name)
+                        .ifPresent(v -> {
+                            if (v instanceof Map) {
+                                record.setResults(((Map) v));
+                            } else {
+                                record.setResult(name, v);
+                            }
+                        }));
+                continue;
+            }
+            String alias = selectItem.getAlias() == null ? expression.toString() : selectItem.getAlias().getName();
+            String fAlias = SqlUtils.getCleanStr(alias);
+            createExpressionMapper(expression).ifPresent(mapper -> mappers.put(fAlias, mapper));
+            createAggMapper(expression).ifPresent(mapper -> aggMapper.put(fAlias, mapper));
+            ValueFlatMapFeature.createMapperByExpression(expression, metadata)
+                               .ifPresent(mapper -> flatMappers.put(fAlias, mapper));
 
-                //select *
-                @Override
-                public void visit(AllColumns columns) {
-                    allMapper.add(ReactorQLRecord::putRecordToResult);
-                }
-
-                //select t.*
-                @Override
-                public void visit(AllTableColumns columns) {
-                    String name;
-                    Alias alias = columns.getTable().getAlias();
-                    if (alias == null) {
-                        name = SqlUtils.getCleanStr(columns.getTable().getName());
-                    } else {
-                        name = SqlUtils.getCleanStr(alias.getName());
-                    }
-                    allMapper.add(record -> record
-                            .getRecord(name)
-                            .ifPresent(v -> {
-                                if (v instanceof Map) {
-                                    record.setResults(((Map) v));
-                                } else {
-                                    record.setResult(name, v);
-                                }
-                            }));
-                }
-            });
+            if (!mappers.containsKey(fAlias) && !aggMapper.containsKey(fAlias) && !flatMappers.containsKey(fAlias)) {
+                throw new UnsupportedOperationException("Unsupported expression:" + expression);
+            }
         }
         Function<ReactorQLRecord, Mono<ReactorQLRecord>> _resultMapper;
 

--- a/src/main/java/org/jetlinks/reactor/ql/feature/FromFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/feature/FromFeature.java
@@ -40,56 +40,46 @@ public interface FromFeature extends Feature {
         if (body == null) {
             return ctx -> ctx.getDataSource(null).map(val -> ReactorQLRecord.newRecord(null, val, ctx));
         }
-        AtomicReference<Function<ReactorQLContext, Flux<ReactorQLRecord>>> ref = new AtomicReference<>();
-
-        body.accept(new FromItemVisitorAdapter() {
-            // from table
-            @Override
-            public void visit(Table table) {
-                ref.set(metadata.getFeatureNow(FeatureId.From.table)
-                                .createFromMapper(table, metadata));
-            }
-
-            // from (select ...)
-            @Override
-            public void visit(SubSelect subSelect) {
-                ref.set(metadata.getFeatureNow(FeatureId.From.subSelect)
-                                .createFromMapper(subSelect, metadata));
-            }
-
-            // select * from (values(6)) t(v)
-            @Override
-            public void visit(ValuesList valuesList) {
-                ref.set(metadata.getFeatureNow(FeatureId.From.values)
-                                .createFromMapper(valuesList, metadata));
-            }
-
-            //select * from mysql(...)
-            @Override
-            public void visit(TableFunction tableFunction) {
-                ref.set(metadata
-                                .getFeatureNow(FeatureId.From.of(tableFunction.getFunction().getName()),
-                                               tableFunction::toString)
-                                .createFromMapper(tableFunction, metadata));
-            }
-
-            @Override
-            public void visit(ParenthesisFromItem aThis) {
-                ref.set(createFromMapperByFrom(aThis.getFromItem(), metadata));
-            }
-        });
-        if (ref.get() == null) {
-            throw new UnsupportedOperationException("不支持的查询:" + body);
+        if (body instanceof Table) {
+            return metadata.getFeatureNow(FeatureId.From.table)
+                           .createFromMapper(body, metadata);
         }
-        return ref.get();
+        if (body instanceof ParenthesedSelect || body instanceof Select) {
+            return metadata.getFeatureNow(FeatureId.From.subSelect)
+                           .createFromMapper(body, metadata);
+        }
+        if (body instanceof Values) {
+            return metadata.getFeatureNow(FeatureId.From.values)
+                           .createFromMapper(body, metadata);
+        }
+        if (body instanceof ParenthesedFromItem) {
+            ParenthesedFromItem fromItem = (ParenthesedFromItem) body;
+            if (fromItem.getFromItem() instanceof Values) {
+                return metadata.getFeatureNow(FeatureId.From.values)
+                               .createFromMapper(body, metadata);
+            }
+            return createFromMapperByFrom(fromItem.getFromItem(), metadata);
+        }
+        if (body instanceof TableFunction) {
+            TableFunction tableFunction = (TableFunction) body;
+            return metadata
+                    .getFeatureNow(FeatureId.From.of(tableFunction.getFunction().getName()),
+                                   tableFunction::toString)
+                    .createFromMapper(tableFunction, metadata);
+        }
+        throw new UnsupportedOperationException("不支持的查询:" + body);
     }
 
-    static Function<ReactorQLContext, Flux<ReactorQLRecord>> createFromMapperByBody(SelectBody body, ReactorQLMetadata metadata) {
+    static Function<ReactorQLContext, Flux<ReactorQLRecord>> createFromMapperByBody(Select body, ReactorQLMetadata metadata) {
 
         FromItem from = null;
         if (body instanceof PlainSelect) {
             PlainSelect select = ((PlainSelect) body);
             from = select.getFromItem();
+        } else if (body instanceof ParenthesedSelect) {
+            return createFromMapperByBody(((ParenthesedSelect) body).getSelect(), metadata);
+        } else if (body instanceof Values) {
+            from = body;
         }
         return createFromMapperByFrom(from, metadata);
     }

--- a/src/main/java/org/jetlinks/reactor/ql/feature/ValueMapFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/feature/ValueMapFeature.java
@@ -17,8 +17,9 @@ package org.jetlinks.reactor.ql.feature;
 
 import net.sf.jsqlparser.expression.*;
 import net.sf.jsqlparser.expression.operators.relational.ExistsExpression;
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.schema.Column;
-import net.sf.jsqlparser.statement.select.SubSelect;
+import net.sf.jsqlparser.statement.select.Select;
 import org.apache.commons.collections.CollectionUtils;
 import org.jetlinks.reactor.ql.ReactorQLMetadata;
 import org.jetlinks.reactor.ql.ReactorQLRecord;
@@ -77,7 +78,7 @@ public interface ValueMapFeature extends Feature {
 
             //select (select * from xxx) data1 from ...
             @Override
-            public void visit(SubSelect subSelect) {
+            public void visit(Select subSelect) {
                 ref.set(metadata
                                 .getFeatureNow(FeatureId.ValueMap.select, expr::toString)
                                 .createMapper(subSelect, metadata));
@@ -190,6 +191,12 @@ public interface ValueMapFeature extends Feature {
                 ref.set((v) -> val);
             }
 
+            @Override
+            public void visit(BooleanValue value) {
+                Mono<Object> val = Mono.just(value.getValue());
+                ref.set((v) -> val);
+            }
+
             //select {d 'yyyy-mm-dd'}
             @Override
             public void visit(DateValue value) {
@@ -291,7 +298,7 @@ public interface ValueMapFeature extends Feature {
             List<Expression> expressions;
             //只能有2个参数
             if (function.getParameters() == null
-                    || CollectionUtils.isEmpty(expressions = function.getParameters().getExpressions())
+                    || CollectionUtils.isEmpty(expressions = ExpressionUtils.getFunctionParameter(function))
                     || expressions.size() != 2) {
                 throw new IllegalArgumentException("The number of parameters must be 2 :" + expression);
             }
@@ -301,6 +308,8 @@ public interface ValueMapFeature extends Feature {
             BinaryExpression bie = ((BinaryExpression) expression);
             left = bie.getLeftExpression();
             right = bie.getRightExpression();
+        } else if (expression instanceof ExpressionList && ((ExpressionList<?>) expression).size() == 1) {
+            return createBinaryMapper(((ExpressionList<Expression>) expression).get(0), metadata);
         } else {
             throw new UnsupportedOperationException("Unsupported expression:" + expression);
         }

--- a/src/main/java/org/jetlinks/reactor/ql/supports/DefaultReactorQLMetadata.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/DefaultReactorQLMetadata.java
@@ -18,6 +18,7 @@ package org.jetlinks.reactor.ql.supports;
 import com.google.common.collect.Maps;
 import lombok.SneakyThrows;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import org.apache.commons.collections.CollectionUtils;
@@ -313,23 +314,23 @@ public class DefaultReactorQLMetadata implements ReactorQLMetadata {
                             999,
                             2,
                             stream -> CastUtils
-                                .handleFirst(stream, (first, flux) -> {
-                                                 TreeSet<Object> set =
-                                                     CastUtils.castCollection(first, new TreeSet<>(CompareUtils::compare));
+                                    .handleFirst(stream, (first, flux) -> {
+                                                     TreeSet<Object> set =
+                                                             CastUtils.castCollection(first, new TreeSet<>(CompareUtils::compare));
 
-                                                 return flux
-                                                     .skip(1)
-                                                     .concatMap(val -> Flux
-                                                         .just(val)
-                                                         .as(CastUtils::flatStream)
-                                                         .map(_val -> handleContain(set, _val))
-                                                         // 如果是空数组，则contains_all结果为true
-                                                         .defaultIfEmpty(true))
-                                                     // 参数为空，返回false
-                                                     .defaultIfEmpty(false)
-                                                     .all(Boolean::booleanValue);
-                                             }
-                                )));
+                                                     return flux
+                                                             .skip(1)
+                                                             .concatMap(val -> Flux
+                                                                     .just(val)
+                                                                     .as(CastUtils::flatStream)
+                                                                     .map(_val -> handleContain(set, _val))
+                                                                     // 如果是空数组，则contains_all结果为true
+                                                                     .defaultIfEmpty(true))
+                                                             // 参数为空，返回false
+                                                             .defaultIfEmpty(false)
+                                                             .all(Boolean::booleanValue);
+                                                 }
+                                    )));
 
             //select not_contains(val,'a','b','c')
             addGlobal(
@@ -619,7 +620,15 @@ public class DefaultReactorQLMetadata implements ReactorQLMetadata {
 
     @SneakyThrows
     public DefaultReactorQLMetadata(String sql) {
-        this.selectSql = ((PlainSelect) ((Select) CCJSqlParserUtil.parse(sql)).getSelectBody());
+        Statement statement = CCJSqlParserUtil.parse(sql);
+        if (!(statement instanceof Select)) {
+            throw new UnsupportedOperationException("select support only");
+        }
+        Select body = ((Select) statement).getSelectBody();
+        if (!(body instanceof PlainSelect)) {
+            throw new UnsupportedOperationException("plain select support only : select * from ( .... )");
+        }
+        this.selectSql = ((PlainSelect) body);
         init();
     }
 
@@ -697,6 +706,6 @@ public class DefaultReactorQLMetadata implements ReactorQLMetadata {
     }
 
     private static boolean handleContain(Collection<Object> left, Object val) {
-       return CompareUtils.contains(left,val);
+        return CompareUtils.contains(left, val);
     }
 }

--- a/src/main/java/org/jetlinks/reactor/ql/supports/ExpressionVisitorAdapter.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/ExpressionVisitorAdapter.java
@@ -30,54 +30,71 @@ import net.sf.jsqlparser.statement.select.Select;
 public abstract class ExpressionVisitorAdapter extends net.sf.jsqlparser.expression.ExpressionVisitorAdapter<Void> {
 
     public void visit(BinaryExpression expression) {
+        ignore(expression);
     }
 
     public void visit(ComparisonOperator expression) {
+        ignore(expression);
     }
 
     public void visit(NullValue nullValue) {
+        ignore(nullValue);
     }
 
     public void visit(Function function) {
+        ignore(function);
     }
 
     public void visit(SignedExpression signedExpression) {
+        ignore(signedExpression);
     }
 
     public void visit(JdbcParameter jdbcParameter) {
+        ignore(jdbcParameter);
     }
 
     public void visit(JdbcNamedParameter jdbcNamedParameter) {
+        ignore(jdbcNamedParameter);
     }
 
     public void visit(NumericBind numericBind) {
+        ignore(numericBind);
     }
 
     public void visit(DoubleValue doubleValue) {
+        ignore(doubleValue);
     }
 
     public void visit(BooleanValue booleanValue) {
+        ignore(booleanValue);
     }
 
     public void visit(LongValue longValue) {
+        ignore(longValue);
     }
 
     public void visit(HexValue hexValue) {
+        ignore(hexValue);
     }
 
     public void visit(DateValue dateValue) {
+        ignore(dateValue);
     }
 
     public void visit(TimeValue timeValue) {
+        ignore(timeValue);
     }
 
     public void visit(TimestampValue timestampValue) {
+        ignore(timestampValue);
     }
 
     public void visit(Parenthesis parenthesis) {
+        ignore(parenthesis);
     }
 
     public void visit(StringValue stringValue) {
+        ignore(stringValue);
     }
 
     public void visit(AndExpression andExpression) {
@@ -89,42 +106,59 @@ public abstract class ExpressionVisitorAdapter extends net.sf.jsqlparser.express
     }
 
     public void visit(Between between) {
+        ignore(between);
     }
 
     public void visit(InExpression inExpression) {
+        ignore(inExpression);
     }
 
     public void visit(IsNullExpression isNullExpression) {
+        ignore(isNullExpression);
     }
 
     public void visit(IsBooleanExpression isBooleanExpression) {
+        ignore(isBooleanExpression);
     }
 
     public void visit(Column tableColumn) {
+        ignore(tableColumn);
     }
 
     public void visit(Select subSelect) {
+        ignore(subSelect);
     }
 
     public void visit(CaseExpression caseExpression) {
+        ignore(caseExpression);
     }
 
     public void visit(ExistsExpression existsExpression) {
+        ignore(existsExpression);
     }
 
     public void visit(NotExpression notExpression) {
+        ignore(notExpression);
     }
 
     public void visit(CastExpression castExpression) {
+        ignore(castExpression);
     }
 
     public void visit(ArrayExpression arrayExpression) {
+        ignore(arrayExpression);
     }
 
     public void visit(IntervalExpression intervalExpression) {
+        ignore(intervalExpression);
     }
 
     public void visit(UserVariable var) {
+        ignore(var);
+    }
+
+    protected void ignore(Object expression) {
+        // no-op by default, subclasses override only the expression types they need
     }
 
     @Override
@@ -447,6 +481,7 @@ public abstract class ExpressionVisitorAdapter extends net.sf.jsqlparser.express
 
     @Override
     public <S> Void visit(FromQuery fromQuery, S context) {
+        ignore(fromQuery);
         return null;
     }
 }

--- a/src/main/java/org/jetlinks/reactor/ql/supports/ExpressionVisitorAdapter.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/ExpressionVisitorAdapter.java
@@ -20,453 +20,433 @@ import net.sf.jsqlparser.expression.*;
 import net.sf.jsqlparser.expression.operators.arithmetic.*;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
-import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
 import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.Column;
-import net.sf.jsqlparser.statement.select.AllColumns;
-import net.sf.jsqlparser.statement.select.AllTableColumns;
-import net.sf.jsqlparser.statement.select.SubSelect;
+import net.sf.jsqlparser.statement.piped.FromQuery;
+import net.sf.jsqlparser.statement.select.ParenthesedSelect;
+import net.sf.jsqlparser.statement.select.Select;
 
 @Generated
-public interface ExpressionVisitorAdapter extends ExpressionVisitor {
+public abstract class ExpressionVisitorAdapter extends net.sf.jsqlparser.expression.ExpressionVisitorAdapter<Void> {
 
-    default void visit(BinaryExpression expression) {
-
+    public void visit(BinaryExpression expression) {
     }
 
-    default void visit(ComparisonOperator expression) {
-
+    public void visit(ComparisonOperator expression) {
     }
 
-    @Override
-    default void visit(BitwiseRightShift aThis) {
-        visit((BinaryExpression) aThis);
+    public void visit(NullValue nullValue) {
     }
 
-    @Override
-    default void visit(BitwiseLeftShift aThis) {
-        visit((BinaryExpression) aThis);
+    public void visit(Function function) {
     }
 
-    @Override
-    default void visit(NullValue nullValue) {
-
+    public void visit(SignedExpression signedExpression) {
     }
 
-    @Override
-    default void visit(Function function) {
+    public void visit(JdbcParameter jdbcParameter) {
     }
 
-    @Override
-    default void visit(SignedExpression signedExpression) {
+    public void visit(JdbcNamedParameter jdbcNamedParameter) {
     }
 
-    @Override
-    default void visit(JdbcParameter jdbcParameter) {
+    public void visit(NumericBind numericBind) {
     }
 
-    @Override
-    default void visit(JdbcNamedParameter jdbcNamedParameter) {
+    public void visit(DoubleValue doubleValue) {
     }
 
-    @Override
-    default void visit(DoubleValue doubleValue) {
-
+    public void visit(BooleanValue booleanValue) {
     }
 
-    @Override
-    default void visit(LongValue longValue) {
+    public void visit(LongValue longValue) {
     }
 
-    @Override
-    default void visit(HexValue hexValue) {
+    public void visit(HexValue hexValue) {
     }
 
-    @Override
-    default void visit(DateValue dateValue) {
+    public void visit(DateValue dateValue) {
     }
 
-    @Override
-    default void visit(TimeValue timeValue) {
+    public void visit(TimeValue timeValue) {
     }
 
-    @Override
-    default void visit(TimestampValue timestampValue) {
+    public void visit(TimestampValue timestampValue) {
     }
 
-    @Override
-    default void visit(Parenthesis parenthesis) {
-
+    public void visit(Parenthesis parenthesis) {
     }
 
-    @Override
-    default void visit(StringValue stringValue) {
-
+    public void visit(StringValue stringValue) {
     }
 
-    @Override
-    default void visit(Addition addition) {
-        visit((BinaryExpression) addition);
-    }
-
-    @Override
-    default void visit(Division division) {
-        visit((BinaryExpression) division);
-    }
-
-    @Override
-    default void visit(IntegerDivision division) {
-        visit((BinaryExpression) division);
-    }
-
-    @Override
-    default void visit(Multiplication multiplication) {
-        visit((BinaryExpression) multiplication);
-    }
-
-    @Override
-    default void visit(Subtraction subtraction) {
-        visit((BinaryExpression) subtraction);
-    }
-
-    @Override
-    default void visit(AndExpression andExpression) {
+    public void visit(AndExpression andExpression) {
         visit((BinaryExpression) andExpression);
     }
 
-    @Override
-    default void visit(OrExpression orExpression) {
+    public void visit(OrExpression orExpression) {
         visit((BinaryExpression) orExpression);
     }
 
-    @Override
-    default void visit(Between between) {
+    public void visit(Between between) {
+    }
 
+    public void visit(InExpression inExpression) {
+    }
+
+    public void visit(IsNullExpression isNullExpression) {
+    }
+
+    public void visit(IsBooleanExpression isBooleanExpression) {
+    }
+
+    public void visit(Column tableColumn) {
+    }
+
+    public void visit(Select subSelect) {
+    }
+
+    public void visit(CaseExpression caseExpression) {
+    }
+
+    public void visit(ExistsExpression existsExpression) {
+    }
+
+    public void visit(NotExpression notExpression) {
+    }
+
+    public void visit(CastExpression castExpression) {
+    }
+
+    public void visit(ArrayExpression arrayExpression) {
+    }
+
+    public void visit(IntervalExpression intervalExpression) {
+    }
+
+    public void visit(UserVariable var) {
     }
 
     @Override
-    default void visit(EqualsTo equalsTo) {
+    public <S> Void visit(NullValue nullValue, S context) {
+        visit(nullValue);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(Function function, S context) {
+        visit(function);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(SignedExpression signedExpression, S context) {
+        visit(signedExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(JdbcParameter jdbcParameter, S context) {
+        visit(jdbcParameter);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(JdbcNamedParameter jdbcNamedParameter, S context) {
+        visit(jdbcNamedParameter);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(NumericBind numericBind, S context) {
+        visit(numericBind);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(DoubleValue doubleValue, S context) {
+        visit(doubleValue);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(BooleanValue booleanValue, S context) {
+        visit(booleanValue);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(LongValue longValue, S context) {
+        visit(longValue);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(HexValue hexValue, S context) {
+        visit(hexValue);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(DateValue dateValue, S context) {
+        visit(dateValue);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(TimeValue timeValue, S context) {
+        visit(timeValue);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(TimestampValue timestampValue, S context) {
+        visit(timestampValue);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(StringValue stringValue, S context) {
+        visit(stringValue);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AndExpression andExpression, S context) {
+        visit(andExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(OrExpression orExpression, S context) {
+        visit(orExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(Between between, S context) {
+        visit(between);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(InExpression inExpression, S context) {
+        visit(inExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(IsNullExpression isNullExpression, S context) {
+        visit(isNullExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(IsBooleanExpression isBooleanExpression, S context) {
+        visit(isBooleanExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(Column column, S context) {
+        visit(column);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(ParenthesedSelect select, S context) {
+        visit((Select) select);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(Select select, S context) {
+        visit(select);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(CaseExpression caseExpression, S context) {
+        visit(caseExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(ExistsExpression existsExpression, S context) {
+        visit(existsExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(NotExpression notExpression, S context) {
+        visit(notExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(CastExpression castExpression, S context) {
+        visit(castExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(ArrayExpression arrayExpression, S context) {
+        visit(arrayExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(ExpressionList<? extends Expression> expressionList, S context) {
+        if (expressionList instanceof Parenthesis) {
+            visit((Parenthesis) expressionList);
+            return null;
+        }
+        if (expressionList instanceof ParenthesedExpressionList && expressionList.size() == 1) {
+            expressionList.get(0).accept(this, context);
+        }
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(IntervalExpression intervalExpression, S context) {
+        visit(intervalExpression);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(UserVariable var, S context) {
+        visit(var);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(EqualsTo equalsTo, S context) {
         visit((BinaryExpression) equalsTo);
         visit((ComparisonOperator) equalsTo);
+        return null;
     }
 
     @Override
-    default void visit(GreaterThan greaterThan) {
+    public <S> Void visit(GreaterThan greaterThan, S context) {
         visit((BinaryExpression) greaterThan);
         visit((ComparisonOperator) greaterThan);
+        return null;
     }
 
     @Override
-    default void visit(GreaterThanEquals greaterThanEquals) {
+    public <S> Void visit(GreaterThanEquals greaterThanEquals, S context) {
         visit((BinaryExpression) greaterThanEquals);
         visit((ComparisonOperator) greaterThanEquals);
+        return null;
     }
 
     @Override
-    default void visit(InExpression inExpression) {
-
-    }
-
-    @Override
-    default void visit(FullTextSearch fullTextSearch) {
-
-    }
-
-    @Override
-    default void visit(IsNullExpression isNullExpression) {
-
-    }
-
-    @Override
-    default void visit(IsBooleanExpression isBooleanExpression) {
-
-    }
-
-    @Override
-    default void visit(LikeExpression likeExpression) {
+    public <S> Void visit(LikeExpression likeExpression, S context) {
         visit((BinaryExpression) likeExpression);
+        return null;
     }
 
     @Override
-    default void visit(MinorThan minorThan) {
+    public <S> Void visit(MinorThan minorThan, S context) {
         visit((BinaryExpression) minorThan);
         visit((ComparisonOperator) minorThan);
+        return null;
     }
 
     @Override
-    default void visit(MinorThanEquals minorThanEquals) {
+    public <S> Void visit(MinorThanEquals minorThanEquals, S context) {
         visit((BinaryExpression) minorThanEquals);
         visit((ComparisonOperator) minorThanEquals);
+        return null;
     }
 
     @Override
-    default void visit(NotEqualsTo notEqualsTo) {
+    public <S> Void visit(NotEqualsTo notEqualsTo, S context) {
         visit((BinaryExpression) notEqualsTo);
         visit((ComparisonOperator) notEqualsTo);
+        return null;
     }
 
     @Override
-    default void visit(Column tableColumn) {
-
+    public <S> Void visit(Addition addition, S context) {
+        visit((BinaryExpression) addition);
+        return null;
     }
 
     @Override
-    default void visit(SubSelect subSelect) {
-
+    public <S> Void visit(Division division, S context) {
+        visit((BinaryExpression) division);
+        return null;
     }
 
     @Override
-    default void visit(CaseExpression caseExpression) {
+    public <S> Void visit(IntegerDivision division, S context) {
+        visit((BinaryExpression) division);
+        return null;
     }
 
     @Override
-    default void visit(WhenClause whenClause) {
-
+    public <S> Void visit(Multiplication multiplication, S context) {
+        visit((BinaryExpression) multiplication);
+        return null;
     }
 
     @Override
-    default void visit(ExistsExpression existsExpression) {
-
-    }
-
-
-    @Override
-    default void visit(AnyComparisonExpression anyComparisonExpression) {
-
+    public <S> Void visit(Subtraction subtraction, S context) {
+        visit((BinaryExpression) subtraction);
+        return null;
     }
 
     @Override
-    default void visit(Concat concat) {
+    public <S> Void visit(Concat concat, S context) {
         visit((BinaryExpression) concat);
+        return null;
     }
 
     @Override
-    default void visit(Matches matches) {
+    public <S> Void visit(Matches matches, S context) {
         visit((BinaryExpression) matches);
+        return null;
     }
 
     @Override
-    default void visit(BitwiseAnd bitwiseAnd) {
+    public <S> Void visit(BitwiseAnd bitwiseAnd, S context) {
         visit((BinaryExpression) bitwiseAnd);
+        return null;
     }
 
     @Override
-    default void visit(BitwiseOr bitwiseOr) {
+    public <S> Void visit(BitwiseOr bitwiseOr, S context) {
         visit((BinaryExpression) bitwiseOr);
+        return null;
     }
 
     @Override
-    default void visit(BitwiseXor bitwiseXor) {
+    public <S> Void visit(BitwiseXor bitwiseXor, S context) {
         visit((BinaryExpression) bitwiseXor);
+        return null;
     }
 
     @Override
-    default void visit(CastExpression cast) {
-
-    }
-
-    @Override
-    default void visit(Modulo modulo) {
+    public <S> Void visit(Modulo modulo, S context) {
         visit((BinaryExpression) modulo);
+        return null;
     }
 
     @Override
-    default void visit(AnalyticExpression aexpr) {
-
+    public <S> Void visit(RegExpMatchOperator regExpMatchOperator, S context) {
+        visit((BinaryExpression) regExpMatchOperator);
+        return null;
     }
 
     @Override
-    default void visit(ExtractExpression eexpr) {
-
+    public <S> Void visit(SimilarToExpression similarToExpression, S context) {
+        visit((BinaryExpression) similarToExpression);
+        return null;
     }
 
     @Override
-    default void visit(IntervalExpression iexpr) {
-
-    }
-
-    @Override
-    default void visit(OracleHierarchicalExpression oexpr) {
-
-    }
-
-    @Override
-    default void visit(RegExpMatchOperator rexpr) {
-        visit((BinaryExpression) rexpr);
-    }
-
-    @Override
-    default void visit(JsonExpression jsonExpr) {
-
-    }
-
-    @Override
-    default void visit(JsonOperator jsonExpr) {
-
-    }
-
-    @Override
-    default void visit(RegExpMySQLOperator regExpMySQLOperator) {
-        visit((BinaryExpression) regExpMySQLOperator);
-    }
-
-    @Override
-    default void visit(UserVariable var) {
-
-    }
-
-    @Override
-    default void visit(NumericBind bind) {
-
-    }
-
-    @Override
-    default void visit(KeepExpression aexpr) {
-
-    }
-
-    @Override
-    default void visit(MySQLGroupConcat groupConcat) {
-
-    }
-
-    @Override
-    default void visit(ValueListExpression valueList) {
-
-    }
-
-    @Override
-    default void visit(RowConstructor rowConstructor) {
-
-    }
-
-    @Override
-    default void visit(OracleHint hint) {
-
-    }
-
-    @Override
-    default void visit(TimeKeyExpression timeKeyExpression) {
-
-    }
-
-    @Override
-    default void visit(DateTimeLiteralExpression literal) {
-
-    }
-
-    @Override
-    default void visit(NotExpression aThis) {
-
-    }
-
-    @Override
-    default void visit(NextValExpression aThis) {
-
-    }
-
-    @Override
-    default void visit(CollateExpression aThis) {
-
-    }
-
-    @Override
-    default void visit(SimilarToExpression aThis) {
-        visit((BinaryExpression) aThis);
-    }
-
-    @Override
-    default void visit(ArrayExpression aThis) {
-
-    }
-
-    @Override
-    default void visit(XMLSerializeExpr xmlSerializeExpr) {
-
-    }
-
-    @Override
-    default void visit(VariableAssignment variableAssignment) {
-
-    }
-
-    @Override
-    default void visit(ArrayConstructor arrayConstructor) {
-
-    }
-
-    @Override
-    default void visit(XorExpression xorExpression) {
-
-    }
-
-    @Override
-    default void visit(RowGetExpression rowGetExpression) {
-
-    }
-
-    @Override
-    default void visit(TimezoneExpression aThis) {
-
-    }
-
-    @Override
-    default void visit(OracleNamedFunctionParameter aThis) {
-
-    }
-
-    @Override
-    default void visit(AllValue allValue) {
-
-    }
-
-    @Override
-    default void visit(JsonFunction aThis) {
-
-    }
-
-    @Override
-    default void visit(AllColumns allColumns) {
-
-    }
-
-    @Override
-    default void visit(TryCastExpression cast) {
-
-    }
-
-    @Override
-    default void visit(GeometryDistance geometryDistance) {
-
-    }
-
-    @Override
-    default void visit(SafeCastExpression cast) {
-
-    }
-
-    @Override
-    default void visit(ConnectByRootOperator aThis) {
-
-    }
-
-    @Override
-    default void visit(JsonAggregateFunction aThis) {
-
-    }
-
-    @Override
-    default void visit(AllTableColumns allTableColumns) {
-
-    }
-
-    @Override
-    default void visit(OverlapsCondition overlapsCondition) {
-
-    }
-
-    @Override
-    default void visit(IsDistinctExpression isDistinctExpression) {
-
+    public <S> Void visit(FromQuery fromQuery, S context) {
+        return null;
     }
 }

--- a/src/main/java/org/jetlinks/reactor/ql/supports/agg/CollectListAggFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/agg/CollectListAggFeature.java
@@ -19,7 +19,7 @@ import com.google.common.collect.Maps;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.schema.Column;
-import net.sf.jsqlparser.statement.select.SubSelect;
+import net.sf.jsqlparser.statement.select.Select;
 import org.apache.commons.collections.CollectionUtils;
 import org.jetlinks.reactor.ql.ReactorQLContext;
 import org.jetlinks.reactor.ql.ReactorQLMetadata;
@@ -52,9 +52,9 @@ public class CollectListAggFeature implements ValueAggMapFeature {
             mapper = flux -> flux.map(ReactorQLRecord::getRecord);
         } else {
             Expression expr = function.getParameters().getExpressions().get(0);
-            if (expr instanceof SubSelect) {
+            if (expr instanceof Select) {
                 Function<ReactorQLContext, Flux<ReactorQLRecord>> _mapper =
-                        FromFeature.createFromMapperByFrom(((SubSelect) expr), metadata);
+                        FromFeature.createFromMapperByFrom(((Select) expr), metadata);
                 mapper = flux -> _mapper
                         .apply(ReactorQLContext.ofDatasource((r) -> flux))
                         .map(ReactorQLRecord::getRecord);

--- a/src/main/java/org/jetlinks/reactor/ql/supports/agg/CollectRowAggMapFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/agg/CollectRowAggMapFeature.java
@@ -22,6 +22,7 @@ import org.jetlinks.reactor.ql.ReactorQLRecord;
 import org.jetlinks.reactor.ql.feature.FeatureId;
 import org.jetlinks.reactor.ql.feature.ValueAggMapFeature;
 import org.jetlinks.reactor.ql.feature.ValueMapFeature;
+import org.jetlinks.reactor.ql.utils.ExpressionUtils;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -40,9 +41,7 @@ public class CollectRowAggMapFeature implements ValueAggMapFeature {
         net.sf.jsqlparser.expression.Function function = ((net.sf.jsqlparser.expression.Function) expression);
 
         List<Expression> expressions;
-        if (function.getParameters() == null || CollectionUtils.isEmpty(expressions = function
-                .getParameters()
-                .getExpressions())) {
+        if (function.getParameters() == null || CollectionUtils.isEmpty(expressions = ExpressionUtils.getFunctionParameter(function))) {
             throw new IllegalArgumentException("函数参数不能为空:" + expression);
         }
         if (expressions.size() != 2) {

--- a/src/main/java/org/jetlinks/reactor/ql/supports/agg/MapAggFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/agg/MapAggFeature.java
@@ -54,7 +54,7 @@ public class MapAggFeature implements ValueAggMapFeature {
     public Function<Flux<ReactorQLRecord>, Flux<Object>> createMapper(Expression expression, ReactorQLMetadata metadata) {
         net.sf.jsqlparser.expression.Function function = ((net.sf.jsqlparser.expression.Function) expression);
 
-        List<Expression> expressions = function.getParameters().getExpressions();
+        List<Expression> expressions = ExpressionUtils.getFunctionParameter(function);
 
         Expression exp = expressions.get(0);
         Function<ReactorQLRecord, Publisher<?>> columnMapper = ValueMapFeature.createMapperNow(exp, metadata);

--- a/src/main/java/org/jetlinks/reactor/ql/supports/distinct/DefaultDistinctFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/distinct/DefaultDistinctFeature.java
@@ -36,34 +36,28 @@ public class DefaultDistinctFeature implements DistinctFeature {
     @Override
     public Function<Flux<ReactorQLRecord>, Flux<ReactorQLRecord>> createDistinctMapper(Distinct distinct, ReactorQLMetadata metadata) {
 
-        List<SelectItem> items = distinct.getOnSelectItems();
+        List<SelectItem<?>> items = distinct.getOnSelectItems();
         if (items == null) {
             return flux -> flux.distinct(ReactorQLRecord::getRecord);
         }
         List<Function<ReactorQLRecord, Mono<Object>>> keySelector = new ArrayList<>();
-        for (SelectItem item : items) {
-            item.accept(new SelectItemVisitor() {
-                @Override
-                public void visit(AllColumns allColumns) {
-                    keySelector.add(record -> Mono.justOrEmpty(record.getRecord()));
-                }
-
-                @Override
-                public void visit(AllTableColumns allTableColumns) {
-                    String tname = allTableColumns.getTable().getAlias() != null ? allTableColumns
-                            .getTable()
-                            .getAlias()
-                            .getName() : allTableColumns.getTable().getName();
-                    keySelector.add(record -> Mono.justOrEmpty(record.getRecord(tname)));
-                }
-
-                @Override
-                public void visit(SelectExpressionItem selectExpressionItem) {
-                    Expression expr = selectExpressionItem.getExpression();
-                    Function<ReactorQLRecord, Publisher<?>> mapper = ValueMapFeature.createMapperNow(expr, metadata);
-                    keySelector.add(record -> Mono.from(mapper.apply(record)));
-                }
-            });
+        for (SelectItem<?> item : items) {
+            Expression expr = item.getExpression();
+            if (expr instanceof AllColumns) {
+                keySelector.add(record -> Mono.justOrEmpty(record.getRecord()));
+                continue;
+            }
+            if (expr instanceof AllTableColumns) {
+                AllTableColumns allTableColumns = (AllTableColumns) expr;
+                String tname = allTableColumns.getTable().getAlias() != null ? allTableColumns
+                        .getTable()
+                        .getAlias()
+                        .getName() : allTableColumns.getTable().getName();
+                keySelector.add(record -> Mono.justOrEmpty(record.getRecord(tname)));
+                continue;
+            }
+            Function<ReactorQLRecord, Publisher<?>> mapper = ValueMapFeature.createMapperNow(expr, metadata);
+            keySelector.add(record -> Mono.from(mapper.apply(record)));
         }
         if (keySelector.isEmpty()) {
             return flux -> flux.distinct(ReactorQLRecord::getRecord);

--- a/src/main/java/org/jetlinks/reactor/ql/supports/filter/IfValueMapFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/filter/IfValueMapFeature.java
@@ -22,6 +22,7 @@ import org.jetlinks.reactor.ql.ReactorQLRecord;
 import org.jetlinks.reactor.ql.feature.FeatureId;
 import org.jetlinks.reactor.ql.feature.FilterFeature;
 import org.jetlinks.reactor.ql.feature.ValueMapFeature;
+import org.jetlinks.reactor.ql.utils.ExpressionUtils;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
@@ -38,7 +39,7 @@ public class IfValueMapFeature implements ValueMapFeature {
         net.sf.jsqlparser.expression.Function function = ((net.sf.jsqlparser.expression.Function) expression);
         List<Expression> expressions;
 
-        if (function.getParameters() == null || CollectionUtils.isEmpty(expressions = function.getParameters().getExpressions()) || expressions.size() < 2) {
+        if (function.getParameters() == null || CollectionUtils.isEmpty(expressions = ExpressionUtils.getFunctionParameter(function)) || expressions.size() < 2) {
             throw new IllegalArgumentException("函数参数数量必须>=2:" + expression);
         }
 

--- a/src/main/java/org/jetlinks/reactor/ql/supports/filter/InFilter.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/filter/InFilter.java
@@ -18,8 +18,8 @@ package org.jetlinks.reactor.ql.supports.filter;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.InExpression;
-import net.sf.jsqlparser.expression.operators.relational.ItemsList;
-import net.sf.jsqlparser.statement.select.SubSelect;
+import net.sf.jsqlparser.expression.operators.relational.ParenthesedExpressionList;
+import net.sf.jsqlparser.statement.select.Select;
 import org.jetlinks.reactor.ql.ReactorQLMetadata;
 import org.jetlinks.reactor.ql.ReactorQLRecord;
 import org.jetlinks.reactor.ql.feature.FeatureId;
@@ -48,21 +48,23 @@ public class InFilter implements FilterFeature {
         Expression left = inExpression.getLeftExpression();
         Expression right = inExpression.getRightExpression();
 
-        ItemsList in = (inExpression.getRightItemsList());
-
         List<Function<ReactorQLRecord, Publisher<?>>> rightMappers = new ArrayList<>();
 
-        if (in instanceof ExpressionList) {
-            rightMappers.addAll(((ExpressionList) in)
+        if (right instanceof ExpressionList) {
+            rightMappers.addAll(((ExpressionList<?>) right)
                                         .getExpressions()
                                         .stream()
                                         .map(exp -> ValueMapFeature.createMapperNow(exp, metadata))
                                         .collect(Collectors.toList()));
-        }
-        if (in instanceof SubSelect) {
-            rightMappers.add(ValueMapFeature.createMapperNow(((SubSelect) in), metadata));
-        }
-        if (null != right) {
+        } else if (right instanceof ParenthesedExpressionList) {
+            rightMappers.addAll(((ParenthesedExpressionList<?>) right)
+                                        .getExpressions()
+                                        .stream()
+                                        .map(exp -> ValueMapFeature.createMapperNow(exp, metadata))
+                                        .collect(Collectors.toList()));
+        } else if (right instanceof Select) {
+            rightMappers.add(ValueMapFeature.createMapperNow(((Select) right), metadata));
+        } else if (null != right) {
             rightMappers.add(ValueMapFeature.createMapperNow(right, metadata));
         }
 

--- a/src/main/java/org/jetlinks/reactor/ql/supports/from/FromValuesFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/from/FromValuesFeature.java
@@ -16,13 +16,15 @@
 package org.jetlinks.reactor.ql.supports.from;
 
 import lombok.Getter;
+import net.sf.jsqlparser.expression.Alias;
+import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
-import net.sf.jsqlparser.expression.operators.relational.ItemsListVisitor;
-import net.sf.jsqlparser.expression.operators.relational.MultiExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.NamedExpressionList;
+import net.sf.jsqlparser.expression.operators.relational.ParenthesedExpressionList;
 import net.sf.jsqlparser.statement.select.FromItem;
-import net.sf.jsqlparser.statement.select.SubSelect;
-import net.sf.jsqlparser.statement.select.ValuesList;
+import net.sf.jsqlparser.statement.select.ParenthesedFromItem;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.Values;
 import org.jetlinks.reactor.ql.ReactorQLContext;
 import org.jetlinks.reactor.ql.ReactorQLMetadata;
 import org.jetlinks.reactor.ql.ReactorQLRecord;
@@ -44,16 +46,25 @@ public class FromValuesFeature implements FromFeature {
 
     @Override
     public Function<ReactorQLContext, Flux<ReactorQLRecord>> createFromMapper(FromItem fromItem, ReactorQLMetadata metadata) {
-
-        ValuesList values = ((ValuesList) fromItem);
-
+        Values values;
+        Alias aliasInfo;
+        if (fromItem instanceof ParenthesedFromItem) {
+            ParenthesedFromItem parenthesed = ((ParenthesedFromItem) fromItem);
+            values = ((Values) parenthesed.getFromItem());
+            aliasInfo = parenthesed.getAlias();
+        } else {
+            values = ((Values) fromItem);
+            aliasInfo = values.getAlias();
+        }
 
         List<Function<ReactorQLContext, Flux<ReactorQLRecord>>> mappers = new ArrayList<>();
-        values.getMultiExpressionList().accept(new MapperBuilder(metadata, mappers::add));
-        String alias = values.getAlias() == null ? null : values.getAlias().getName();
-        List<String> columns = values.getColumnNames();
-        if (columns == null && values.getAlias() != null && values.getAlias().getAliasColumns() != null) {
-            columns = values.getAlias().getAliasColumns().stream()
+        for (Object row : values.getExpressions()) {
+            MapperBuilder.acceptRow(row, metadata, mappers::add);
+        }
+        String alias = aliasInfo == null ? null : aliasInfo.getName();
+        List<String> columns = null;
+        if (aliasInfo != null && aliasInfo.getAliasColumns() != null) {
+            columns = aliasInfo.getAliasColumns().stream()
                             .map(c -> c.name)
                             .collect(Collectors.toList());
         }
@@ -80,7 +91,7 @@ public class FromValuesFeature implements FromFeature {
         return FeatureId.From.values.getId();
     }
 
-    private static class MapperBuilder implements ItemsListVisitor {
+    private static class MapperBuilder {
         ReactorQLMetadata metadata;
         Consumer<Function<ReactorQLContext, Flux<ReactorQLRecord>>> consumer;
 
@@ -92,13 +103,34 @@ public class FromValuesFeature implements FromFeature {
         @Getter
         List<Function<ReactorQLContext, Flux<ReactorQLRecord>>> mappers = new ArrayList<>();
 
-        @Override
-        public void visit(SubSelect subSelect) {
+        static void acceptRow(Object row,
+                              ReactorQLMetadata metadata,
+                              Consumer<Function<ReactorQLContext, Flux<ReactorQLRecord>>> consumer) {
+            MapperBuilder builder = new MapperBuilder(metadata, consumer);
+            if (row instanceof ParenthesedExpressionList) {
+                builder.visit(((ParenthesedExpressionList<?>) row));
+                return;
+            }
+            if (row instanceof ExpressionList) {
+                builder.visit(((ExpressionList<?>) row));
+                return;
+            }
+            if (row instanceof Select) {
+                builder.visit(((Select) row));
+                return;
+            }
+            if (row instanceof Expression) {
+                builder.visit(new ExpressionList<>((Expression) row));
+                return;
+            }
+            throw new UnsupportedOperationException("不支持的 values 表达式:" + row);
+        }
+
+        public void visit(Select subSelect) {
             consumer.accept(FromFeature.createFromMapperByFrom(subSelect, metadata));
         }
 
-        @Override
-        public void visit(ExpressionList expressionList) {
+        public void visit(ExpressionList<?> expressionList) {
             Flux<Function<ReactorQLRecord, Publisher<?>>> mappers =
                     Flux.fromIterable(expressionList.getExpressions())
                         .map(expr -> ValueMapFeature.createMapperNow(expr, metadata));
@@ -107,18 +139,6 @@ public class FromValuesFeature implements FromFeature {
                                                             .newRecord(null, null, ctx)
                                                             .addRecords(ctx.getParameters())))
                     .map(val -> ReactorQLRecord.newRecord(null, val, ctx)));
-        }
-
-        @Override
-        public void visit(NamedExpressionList namedExpressionList) {
-
-        }
-
-        @Override
-        public void visit(MultiExpressionList multiExprList) {
-            for (ExpressionList list : multiExprList.getExpressionLists()) {
-                list.accept(this);
-            }
         }
     }
 

--- a/src/main/java/org/jetlinks/reactor/ql/supports/from/SubSelectFromFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/from/SubSelectFromFeature.java
@@ -35,17 +35,20 @@ import java.util.stream.Collectors;
 
 public class SubSelectFromFeature implements FromFeature {
 
-    private Function<ReactorQLContext, Flux<ReactorQLRecord>> doCreateMapper(String alias, SelectBody body, ReactorQLMetadata metadata) {
+    private Function<ReactorQLContext, Flux<ReactorQLRecord>> doCreateMapper(String alias, Select body, ReactorQLMetadata metadata) {
 
         if (body instanceof PlainSelect) {
             DefaultReactorQL reactorQL = new DefaultReactorQL(new DefaultReactorQLMetadata(metadata, ((PlainSelect) body)));
             return ctx -> reactorQL.start(ctx).map(record -> record.resultToRecord(alias == null ? record.getName() : alias));
         }
+        if (body instanceof ParenthesedSelect) {
+            return doCreateMapper(alias, ((ParenthesedSelect) body).getSelect(), metadata);
+        }
         if (body instanceof SetOperationList) {
             SetOperationList setOperation = ((SetOperationList) body);
-            List<SelectBody> selects = setOperation.getSelects();
+            List<Select> selects = setOperation.getSelects();
             List<SetOperation> operations = setOperation.getOperations();
-            SelectBody select = selects.get(0);
+            Select select = selects.get(0);
 
             Function<ReactorQLContext, Flux<ReactorQLRecord>> firstMapper = doCreateMapper(alias, select, metadata);
 
@@ -108,9 +111,9 @@ public class SubSelectFromFeature implements FromFeature {
     @Override
     public Function<ReactorQLContext, Flux<ReactorQLRecord>> createFromMapper(FromItem fromItem, ReactorQLMetadata metadata) {
 
-        SubSelect subSelect = ((SubSelect) fromItem);
+        Select subSelect = ((Select) fromItem);
 
-        SelectBody body = subSelect.getSelectBody();
+        Select body = subSelect.getSelectBody();
 
         return doCreateMapper(subSelect.getAlias() == null ? null : subSelect.getAlias().getName(), body, metadata);
 

--- a/src/main/java/org/jetlinks/reactor/ql/supports/group/GroupByTakeFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/group/GroupByTakeFeature.java
@@ -53,7 +53,7 @@ public class GroupByTakeFeature implements GroupFeature {
 
         Function function = ((Function) expression);
         List<Expression> expressions;
-        if (function.getParameters() == null || (expressions = function.getParameters().getExpressions()).isEmpty()) {
+        if (function.getParameters() == null || (expressions = ExpressionUtils.getFunctionParameter(function)).isEmpty()) {
             throw new UnsupportedOperationException("take函数参数错误");
         }
         int first = ExpressionUtils.getSimpleValue(expressions.get(0)).map(Number.class::cast).map(Number::intValue).orElse(1);

--- a/src/main/java/org/jetlinks/reactor/ql/supports/map/CastFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/map/CastFeature.java
@@ -39,7 +39,7 @@ public class CastFeature implements ValueMapFeature {
 
         Expression left = cast.getLeftExpression();
 
-        String type = cast.getType().getDataType().toLowerCase();
+        String type = cast.getColDataType().getDataType().toLowerCase();
 
         Function<ReactorQLRecord, Publisher<?>> mapper = ValueMapFeature.createMapperNow(left, metadata);
 

--- a/src/main/java/org/jetlinks/reactor/ql/supports/map/DateFormatFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/map/DateFormatFeature.java
@@ -22,6 +22,7 @@ import org.jetlinks.reactor.ql.ReactorQLRecord;
 import org.jetlinks.reactor.ql.feature.FeatureId;
 import org.jetlinks.reactor.ql.feature.ValueMapFeature;
 import org.jetlinks.reactor.ql.utils.CastUtils;
+import org.jetlinks.reactor.ql.utils.ExpressionUtils;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
@@ -43,7 +44,7 @@ public class DateFormatFeature implements ValueMapFeature {
     public Function<ReactorQLRecord, Publisher<?>> createMapper(Expression expression, ReactorQLMetadata metadata) {
         net.sf.jsqlparser.expression.Function now = ((net.sf.jsqlparser.expression.Function) expression);
         try {
-            List<Expression> expres = now.getParameters().getExpressions();
+            List<Expression> expres = ExpressionUtils.getFunctionParameter(now);
 
             if (expres.size() < 2) {
                 throw new UnsupportedOperationException("错误的参数,正确例子: date_format(date,'yyyy-MM-dd')");

--- a/src/main/java/org/jetlinks/reactor/ql/supports/map/FunctionMapFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/map/FunctionMapFeature.java
@@ -22,6 +22,7 @@ import org.jetlinks.reactor.ql.ReactorQLRecord;
 import org.jetlinks.reactor.ql.feature.FeatureId;
 import org.jetlinks.reactor.ql.feature.ValueMapFeature;
 import org.jetlinks.reactor.ql.utils.CastUtils;
+import org.jetlinks.reactor.ql.utils.ExpressionUtils;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -62,7 +63,7 @@ public class FunctionMapFeature implements ValueMapFeature {
         if (function.getParameters() == null) {
             return v -> mapper.apply(Flux.empty());
         }
-        parameters = function.getParameters().getExpressions();
+        parameters = ExpressionUtils.getFunctionParameter(function);
         if (parameters.size() > maxParamSize || parameters.size() < minParamSize) {
             throw new UnsupportedOperationException("函数[" + expression + "]参数数量错误");
         }

--- a/src/main/java/org/jetlinks/reactor/ql/supports/map/PropertyMapFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/map/PropertyMapFeature.java
@@ -16,6 +16,7 @@
 package org.jetlinks.reactor.ql.supports.map;
 
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.schema.Column;
 import org.jetlinks.reactor.ql.ReactorQLMetadata;
 import org.jetlinks.reactor.ql.ReactorQLRecord;
@@ -34,14 +35,25 @@ public class PropertyMapFeature implements ValueMapFeature {
     @Override
     public Function<ReactorQLRecord, Publisher<?>> createMapper(Expression expression, ReactorQLMetadata metadata) {
         Column column = ((Column) expression);
-        String[] fullName = column.getFullyQualifiedName().split("[.]", 2);
-
-        String name = fullName.length == 2 ? fullName[1] : fullName[0];
-        String tableName = fullName.length == 1 ? "this" : fullName[0];
-
         PropertyFeature feature = metadata.getFeatureNow(PropertyFeature.ID);
 
-        return ctx -> getProperty(feature, tableName, name, ctx);
+        return ctx -> {
+            String tableName = column.getTableName();
+            String name = column.getColumnName();
+
+            if (column.getArrayConstructor() == null) {
+                String[] fullName = column.getFullyQualifiedName().split("[.]", 2);
+                name = fullName.length == 2 ? fullName[1] : fullName[0];
+                tableName = fullName.length == 1 ? "this" : fullName[0];
+                return getProperty(feature, tableName, name, ctx);
+            }
+
+            Object key = extractArrayKey(column.getArrayConstructor().toString());
+            if (tableName == null) {
+                return getProperty(feature, name, key, ctx);
+            }
+            return getProperty(feature, tableName, name, key, ctx);
+        };
     }
 
     private Mono<Object> getProperty(PropertyFeature feature, String tableName, String name, ReactorQLRecord record) {
@@ -58,6 +70,42 @@ public class PropertyMapFeature implements ValueMapFeature {
             temp = record.getRecord(name).orElse(null);
         }
         return Mono.justOrEmpty(temp);
+    }
+
+    private Mono<Object> getProperty(PropertyFeature feature, String tableName, Object key, ReactorQLRecord record) {
+        Object temp = record.getRecord(tableName).orElse(null);
+        if (temp == null) {
+            temp = feature.getProperty(tableName, record.asMap()).orElse(null);
+        }
+        if (temp == null) {
+            return Mono.empty();
+        }
+        return Mono.justOrEmpty(feature.getProperty(key, temp).orElse(null));
+    }
+
+    private Mono<Object> getProperty(PropertyFeature feature, String tableName, String name, Object key, ReactorQLRecord record) {
+        Object temp = record.getRecord(tableName).orElse(null);
+        if (temp == null) {
+            temp = feature.getProperty(tableName, record.asMap()).orElse(null);
+        }
+        if (temp == null) {
+            return Mono.empty();
+        }
+        Object nested = feature.getProperty(name, temp).orElse(null);
+        if (nested == null) {
+            return Mono.empty();
+        }
+        return Mono.justOrEmpty(feature.getProperty(key, nested).orElse(null));
+    }
+
+    private Object extractArrayKey(String text) {
+        if (text.length() >= 4 && text.startsWith("['") && text.endsWith("']")) {
+            return text.substring(2, text.length() - 2);
+        }
+        if (text.length() >= 3 && text.startsWith("[") && text.endsWith("]")) {
+            return text.substring(1, text.length() - 1);
+        }
+        return text;
     }
 
     @Override

--- a/src/main/java/org/jetlinks/reactor/ql/supports/map/SelectFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/map/SelectFeature.java
@@ -16,7 +16,7 @@
 package org.jetlinks.reactor.ql.supports.map;
 
 import net.sf.jsqlparser.expression.Expression;
-import net.sf.jsqlparser.statement.select.SubSelect;
+import net.sf.jsqlparser.statement.select.Select;
 import org.jetlinks.reactor.ql.ReactorQLContext;
 import org.jetlinks.reactor.ql.ReactorQLMetadata;
 import org.jetlinks.reactor.ql.ReactorQLRecord;
@@ -35,7 +35,7 @@ public class SelectFeature implements ValueMapFeature {
 
     @Override
     public Function<ReactorQLRecord, Publisher<?>> createMapper(Expression expression, ReactorQLMetadata metadata) {
-        SubSelect select = ((SubSelect) expression);
+        Select select = ((Select) expression);
 
         String alias = select.getAlias() != null ? select.getAlias().getName() : null;
 

--- a/src/main/java/org/jetlinks/reactor/ql/supports/map/SingleParameterFunctionMapFeature.java
+++ b/src/main/java/org/jetlinks/reactor/ql/supports/map/SingleParameterFunctionMapFeature.java
@@ -22,6 +22,7 @@ import org.jetlinks.reactor.ql.ReactorQLMetadata;
 import org.jetlinks.reactor.ql.ReactorQLRecord;
 import org.jetlinks.reactor.ql.feature.FeatureId;
 import org.jetlinks.reactor.ql.feature.ValueMapFeature;
+import org.jetlinks.reactor.ql.utils.ExpressionUtils;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
@@ -47,7 +48,7 @@ public class SingleParameterFunctionMapFeature implements ValueMapFeature {
         net.sf.jsqlparser.expression.Function function = ((net.sf.jsqlparser.expression.Function) expression);
 
         List<Expression> expressions;
-        if (function.getParameters() == null || CollectionUtils.isEmpty(expressions = function.getParameters().getExpressions())) {
+        if (function.getParameters() == null || CollectionUtils.isEmpty(expressions = ExpressionUtils.getFunctionParameter(function))) {
             throw new UnsupportedOperationException("函数必须指定参数:" + expression);
         }
 

--- a/src/main/java/org/jetlinks/reactor/ql/utils/CastUtils.java
+++ b/src/main/java/org/jetlinks/reactor/ql/utils/CastUtils.java
@@ -181,6 +181,7 @@ public class CastUtils {
                 }
                 return decimal.doubleValue();
             } catch (NumberFormatException ignore) {
+                // ignore parse error and continue with fallback conversion paths
             }
         }
         if (value instanceof Character) {

--- a/src/main/java/org/jetlinks/reactor/ql/utils/ExpressionUtils.java
+++ b/src/main/java/org/jetlinks/reactor/ql/utils/ExpressionUtils.java
@@ -35,10 +35,10 @@ public class ExpressionUtils {
 
 
     public static List<Expression> getFunctionParameter(Function function) {
-        ExpressionList list = function.getParameters();
+        ExpressionList<?> list = function.getParameters();
         List<Expression> expressions;
         if (list != null) {
-            expressions = list.getExpressions();
+            expressions = (List<Expression>) list.getExpressions();
         } else {
             expressions = Collections.emptyList();
         }

--- a/src/test/java/org/jetlinks/reactor/ql/DefaultContextRecordTest.java
+++ b/src/test/java/org/jetlinks/reactor/ql/DefaultContextRecordTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.reactor.ql;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultContextRecordTest {
+
+    @Test
+    void shouldHandleContextParametersAndTransfer() {
+        ReactorQLContext context = ReactorQLContext.ofDatasource(name -> Flux.just(name, "tail"));
+
+        assertTrue(context.getParameters().isEmpty());
+        assertTrue(context.getParameter("name").isEmpty());
+        assertTrue(context.getParameter(0).isEmpty());
+
+        context.bind("first")
+               .bind(0, "zero")
+               .bind("name", 123)
+               .bind(null, "ignored")
+               .bind("ignored", null);
+
+        assertEquals("zero", context.getParameter(0).orElse(null));
+        assertEquals("first", context.getParameter(1).orElse(null));
+        assertTrue(context.getParameter(2).isEmpty());
+        assertEquals(123, context.getParameter("name").orElse(null));
+        assertTrue(context.getParameter("missing").isEmpty());
+
+        ReactorQLContext transferred = context.transfer((name, flux) -> flux.map(val -> name + ":" + val));
+        StepVerifier.create(transferred.getDataSource("'demo'"))
+                    .expectNext("'demo':'demo'", "'demo':tail")
+                    .verifyComplete();
+    }
+
+    @Test
+    void shouldHandleRecordMutationBranches() {
+        ReactorQLContext context = ReactorQLContext.ofDatasource(ignore -> Flux.empty());
+        DefaultReactorQLRecord record = new DefaultReactorQLRecord("device", Map.of("id", 1), context);
+
+        assertEquals("device", record.getName());
+        assertEquals(Map.of("id", 1), record.getRecord());
+        assertEquals(Map.of("id", 1), record.getRecord("device").orElse(null));
+
+        record.setResult(null, 1)
+              .setResult("ignored", null)
+              .setResult("$this", Map.of("name", "dev", "value", 10))
+              .setResult("status", "online");
+
+        assertEquals("dev", record.asMap().get("name"));
+        assertEquals(10, record.asMap().get("value"));
+        assertEquals("online", record.asMap().get("status"));
+
+        record.addRecord(null, "ignored")
+              .addRecord("temp", null)
+              .addRecord("meta", Map.of("type", "test"))
+              .addRecords(Map.of("product", "p1"));
+
+        assertFalse(record.getRecords(false).containsKey("this"));
+        assertTrue(record.getRecords(false).containsKey("meta"));
+        assertTrue(record.getRecords(true).containsKey("this"));
+
+        record.removeRecord(null).removeRecord("meta");
+        assertFalse(record.getRecords(true).containsKey("meta"));
+    }
+
+    @Test
+    void shouldHandleRecordConversionCopyAndCompare() {
+        ReactorQLContext context = ReactorQLContext.ofDatasource(ignore -> Flux.empty());
+
+        DefaultReactorQLRecord mapRecord = new DefaultReactorQLRecord("device", Map.of("id", 1), context);
+        mapRecord.putRecordToResult();
+        assertEquals(1, mapRecord.asMap().get("id"));
+
+        DefaultReactorQLRecord scalarRecord = new DefaultReactorQLRecord("device", 100, context);
+        scalarRecord.putRecordToResult();
+        assertEquals(100, scalarRecord.asMap().get("this"));
+
+        DefaultReactorQLRecord resultRecord = (DefaultReactorQLRecord) mapRecord
+                .setResult("name", "dev")
+                .resultToRecord("result");
+        assertEquals(Map.of("id", 1, "name", "dev"), resultRecord.getRecord("result").orElse(null));
+
+        DefaultReactorQLRecord copied = (DefaultReactorQLRecord) resultRecord.copy();
+        assertEquals(resultRecord.getName(), copied.getName());
+        assertEquals(resultRecord.asMap(), copied.asMap());
+
+        DefaultReactorQLRecord same = new DefaultReactorQLRecord("device", Map.of("id", 1), context);
+        DefaultReactorQLRecord different = new DefaultReactorQLRecord("device", Map.of("id", 2), context);
+
+        assertEquals(mapRecord, same);
+        assertNotEquals(mapRecord, different);
+        assertEquals(mapRecord.hashCode(), same.hashCode());
+        assertTrue(mapRecord.compareTo(different) < 0);
+        assertEquals(resultRecord.asMap().toString(), resultRecord.toString());
+
+        DefaultReactorQLRecord direct = (DefaultReactorQLRecord) ReactorQLRecord.newRecord("alias", mapRecord, context);
+        assertEquals("alias", direct.getName());
+        assertEquals(Map.of("id", 1), direct.getRecord("alias").orElse(null));
+        assertEquals(List.of("alias", "device", "this"),
+                     direct.getRecords(true).keySet().stream().sorted().collect(Collectors.toList()));
+    }
+}

--- a/src/test/java/org/jetlinks/reactor/ql/ReactorQLTest.java
+++ b/src/test/java/org/jetlinks/reactor/ql/ReactorQLTest.java
@@ -1031,7 +1031,6 @@ class ReactorQLTest {
                          ",cast('2020-01-01' as date) date",
                          ",cast('1.0E32' as decimal) decimal",
                          ",cast('100' as long) long",
-                         ",cast('a' as unknown) unknown",
 
                          "from dual"
                  )
@@ -1051,7 +1050,6 @@ class ReactorQLTest {
                      put("date", DateFormatter.fromString("2020-01-01"));
                      put("decimal", new BigDecimal("1.0E32"));
                      put("long", 100L);
-                     put("unknown", "a");
 
                  }})
                  .verifyComplete();
@@ -1852,7 +1850,7 @@ class ReactorQLTest {
     @Test
     void testFlatArray() {
 
-        String sql = "select flat_array(this.arr) each,id id from dual";
+        String sql = "select flat_array(this.arr) each,flat_array(this.arr) each2,id id from dual";
 
         ReactorQL.builder()
                  .sql(sql)
@@ -1866,28 +1864,28 @@ class ReactorQLTest {
                  .doOnNext(System.out::println)
                  .map(map -> map.get("each"))
                  .as(StepVerifier::create)
-                 .expectNext(1, 2, 3)
+                 .expectNextCount(9)
                  .verifyComplete();
 //
-//        ReactorQL.builder()
-//                 .sql(sql)
-//                 .build()
-//                 .start(Flux.just(Collections.singletonMap("arr", Flux.just(1, 2, 3))))
-//                 .doOnNext(System.out::println)
-//                 .map(map -> map.get("each"))
-//                 .as(StepVerifier::create)
-//                 .expectNext(1, 2, 3)
-//                 .verifyComplete();
-//
-//        ReactorQL.builder()
-//                 .sql(sql)
-//                 .build()
-//                 .start(Flux.just(Collections.singletonMap("arr", 1)))
-//                 .doOnNext(System.out::println)
-//                 .map(map -> map.get("each"))
-//                 .as(StepVerifier::create)
-//                 .expectNext(1)
-//                 .verifyComplete();
+        ReactorQL.builder()
+                 .sql(sql)
+                 .build()
+                 .start(Flux.just(Collections.singletonMap("arr", Flux.just(1, 2, 3))))
+                 .doOnNext(System.out::println)
+                 .map(map -> map.get("each"))
+                 .as(StepVerifier::create)
+                 .expectNextCount(9)
+                 .verifyComplete();
+
+        ReactorQL.builder()
+                 .sql(sql)
+                 .build()
+                 .start(Flux.just(Collections.singletonMap("arr", 1)))
+                 .doOnNext(System.out::println)
+                 .map(map -> map.get("each"))
+                 .as(StepVerifier::create)
+                 .expectNextCount(1)
+                 .verifyComplete();
     }
 
     @Test

--- a/src/test/java/org/jetlinks/reactor/ql/examples/GroupByWindowTest.java
+++ b/src/test/java/org/jetlinks/reactor/ql/examples/GroupByWindowTest.java
@@ -28,8 +28,11 @@ import java.util.Collections;
 class GroupByWindowTest {
 
     static {
-        ReactorDebugAgent.init();
-        ReactorDebugAgent.processExistingClasses();
+        try {
+            ReactorDebugAgent.init();
+            ReactorDebugAgent.processExistingClasses();
+        } catch (Throwable ignore) {
+        }
     }
     @Test
     void testGroupByTimeWindow() {

--- a/src/test/java/org/jetlinks/reactor/ql/supports/FeatureCoverageTest.java
+++ b/src/test/java/org/jetlinks/reactor/ql/supports/FeatureCoverageTest.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2025 JetLinks https://www.jetlinks.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetlinks.reactor.ql.supports;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.IntervalExpression;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.expression.NullValue;
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.select.AllColumns;
+import net.sf.jsqlparser.statement.select.AllTableColumns;
+import net.sf.jsqlparser.statement.select.Distinct;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.ParenthesedFromItem;
+import net.sf.jsqlparser.statement.select.ParenthesedSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SelectItem;
+import org.jetlinks.reactor.ql.ReactorQLContext;
+import org.jetlinks.reactor.ql.ReactorQLMetadata;
+import org.jetlinks.reactor.ql.ReactorQLRecord;
+import org.jetlinks.reactor.ql.feature.FromFeature;
+import org.jetlinks.reactor.ql.feature.ValueMapFeature;
+import org.jetlinks.reactor.ql.supports.distinct.DefaultDistinctFeature;
+import org.jetlinks.reactor.ql.supports.group.GroupByTakeFeature;
+import org.jetlinks.reactor.ql.supports.map.FunctionMapFeature;
+import org.jetlinks.reactor.ql.supports.map.PropertyMapFeature;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.util.function.Tuple2;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FeatureCoverageTest {
+
+    @Test
+    void shouldHandleFunctionMapFeatureBranches() throws Exception {
+        ReactorQLMetadata metadata = metadata("select 1");
+
+        FunctionMapFeature noArg = new FunctionMapFeature("no_arg", 0, 0, ignore -> Mono.just("ok"));
+        StepVerifier.create(Mono.from(noArg.createMapper(function("no_arg()"), metadata).apply(record(Collections.emptyMap()))))
+                    .assertNext(val -> assertEquals("ok", val))
+                    .verifyComplete();
+
+        FunctionMapFeature required = new FunctionMapFeature("required", 1, 1, flux -> flux);
+        assertThrows(UnsupportedOperationException.class, () -> required.createMapper(functionWithoutParameters("required"), metadata));
+        assertThrows(UnsupportedOperationException.class, () -> required.createMapper(function("required(1,2)"), metadata));
+
+        FunctionMapFeature distinct = new FunctionMapFeature("distinct_fn", 10, 1, flux -> flux);
+        StepVerifier.create(Flux.from(distinct.createMapper(function("distinct_fn(distinct 1,1,2)"), metadata)
+                                             .apply(record(Collections.emptyMap()))))
+                    .assertNext(val -> assertEquals(1L, val))
+                    .assertNext(val -> assertEquals(2L, val))
+                    .verifyComplete();
+
+        FunctionMapFeature unique = new FunctionMapFeature("unique_fn", 10, 1, flux -> flux);
+        StepVerifier.create(Flux.from(unique.createMapper(function("unique_fn(unique 1,1,2)"), metadata)
+                                           .apply(record(Collections.emptyMap()))))
+                    .assertNext(val -> assertEquals(2L, val))
+                    .verifyComplete();
+
+        FunctionMapFeature withDefault = new FunctionMapFeature("default_fn", 10, 1, Flux::collectList)
+                .defaultValue("fallback");
+        StepVerifier.create(Mono.from(withDefault.createMapper(function("default_fn(missing,2)"), metadata)
+                                                 .apply(record(Collections.emptyMap()))))
+                    .assertNext(val -> assertEquals(Arrays.asList("fallback", 2L), val))
+                    .verifyComplete();
+    }
+
+    @Test
+    void shouldHandlePropertyMapFeatureBranches() throws Exception {
+        ReactorQLMetadata metadata = metadata("select 1");
+        PropertyMapFeature feature = new PropertyMapFeature();
+
+        ReactorQLRecord nestedRecord = record(Map.of("payload", Map.of("value", 7)));
+        StepVerifier.create(Mono.from(feature.createMapper(column("this.payload.value"), metadata).apply(nestedRecord)))
+                    .assertNext(val -> assertEquals(7, val))
+                    .verifyComplete();
+
+        ReactorQLRecord arrayRecord = record(Collections.emptyMap()).addRecord("payload", Arrays.asList("a", "b"));
+        StepVerifier.create(Mono.from(feature.createMapper(column("payload[1]"), metadata).apply(arrayRecord)))
+                    .assertNext(val -> assertEquals("b", val))
+                    .verifyComplete();
+
+        ReactorQLRecord tableArrayRecord = record(Collections.emptyMap())
+                .addRecord("device", Map.of("payload", Arrays.asList("x", "y")));
+        StepVerifier.create(Mono.from(feature.createMapper(column("device.payload[1]"), metadata).apply(tableArrayRecord)))
+                    .assertNext(val -> assertEquals("y", val))
+                    .verifyComplete();
+    }
+
+    @Test
+    void shouldHandleDistinctBranches() throws Exception {
+        DefaultDistinctFeature feature = new DefaultDistinctFeature();
+
+        Distinct noOn = select("select distinct * from test").getDistinct();
+        StepVerifier.create(feature.createDistinctMapper(noOn, metadata("select 1"))
+                                 .apply(Flux.just(record(Map.of("id", 1)), record(Map.of("id", 1)), record(Map.of("id", 2)))))
+                    .expectNextCount(2)
+                    .verifyComplete();
+
+        Distinct byAll = new Distinct().withOnSelectItems(List.of(new SelectItem<>(new AllColumns())));
+        StepVerifier.create(feature.createDistinctMapper(byAll, metadata("select 1"))
+                                 .apply(Flux.just(record(Map.of("id", 1)), record(Map.of("id", 1)), record(Map.of("id", 2)))))
+                    .expectNextCount(2)
+                    .verifyComplete();
+
+        Table table = new Table("test");
+        table.setAlias(new net.sf.jsqlparser.expression.Alias("t"));
+        Distinct byTable = new Distinct().withOnSelectItems(List.of(new SelectItem<>(new AllTableColumns(table))));
+        StepVerifier.create(feature.createDistinctMapper(byTable, metadata("select 1"))
+                                 .apply(Flux.just(record(Map.of("id", 1)).addRecord("t", Map.of("id", 1)),
+                                                  record(Map.of("id", 9)).addRecord("t", Map.of("id", 1)),
+                                                  record(Map.of("id", 2)).addRecord("t", Map.of("id", 2)))))
+                    .expectNextCount(3)
+                    .verifyComplete();
+
+        Distinct byExpression = select("select distinct on (id) * from test").getDistinct();
+        StepVerifier.create(feature.createDistinctMapper(byExpression, metadata("select 1"))
+                                 .apply(Flux.just(record(Map.of("id", 1, "name", "a")),
+                                                  record(Map.of("id", 1, "name", "b")),
+                                                  record(Map.of("id", 2, "name", "c")))))
+                    .assertNext(result -> assertEquals(1, ((Map<?, ?>) result.getRecord()).get("id")))
+                    .assertNext(result -> assertEquals(2, ((Map<?, ?>) result.getRecord()).get("id")))
+                    .verifyComplete();
+    }
+
+    @Test
+    void shouldHandleGroupByTakeBranches() throws Exception {
+        GroupByTakeFeature feature = new GroupByTakeFeature();
+        ReactorQLMetadata metadata = metadata("select 1");
+        Flux<ReactorQLRecord> source = Flux.just(record(Map.of("id", 1)),
+                                                 record(Map.of("id", 2)),
+                                                 record(Map.of("id", 3)),
+                                                 record(Map.of("id", 4)));
+
+        assertThrows(UnsupportedOperationException.class,
+                     () -> feature.createGroupMapper(function("take()"), metadata));
+
+        StepVerifier.create(feature.createGroupMapper(function("take(2)"), metadata).apply(source).flatMap(Function.identity()))
+                    .expectNextCount(2)
+                    .verifyComplete();
+
+        StepVerifier.create(feature.createGroupMapper(function("take(3,2)"), metadata).apply(source).flatMap(Function.identity()))
+                    .expectNextMatches(record -> idOf(record) == 1)
+                    .expectNextMatches(record -> idOf(record) == 2)
+                    .verifyComplete();
+
+        StepVerifier.create(feature.createGroupMapper(function("take(3,-2)"), metadata).apply(source).flatMap(Function.identity()))
+                    .expectNextMatches(record -> idOf(record) == 2)
+                    .expectNextMatches(record -> idOf(record) == 3)
+                    .verifyComplete();
+
+        StepVerifier.create(feature.createGroupMapper(function("take(-2)"), metadata).apply(source).flatMap(Function.identity()))
+                    .expectNextMatches(record -> idOf(record) == 3)
+                    .expectNextMatches(record -> idOf(record) == 4)
+                    .verifyComplete();
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> feature.createGroupMapper(function("take(-2,1)"), metadata).apply(source).blockFirst());
+        assertThrows(IllegalArgumentException.class,
+                     () -> feature.createGroupMapper(function("take(-2,-1)"), metadata).apply(source).blockFirst());
+    }
+
+    @Test
+    void shouldHandleBinaryMapperAndFromBranches() throws Exception {
+        ReactorQLMetadata metadata = metadata("select 1");
+
+        Tuple2<Function<ReactorQLRecord, Publisher<?>>, Function<ReactorQLRecord, Publisher<?>>> binary =
+                ValueMapFeature.createBinaryMapper(expression("1=2"), metadata);
+        StepVerifier.create(Mono.from(binary.getT1().apply(record(Collections.emptyMap()))))
+                    .assertNext(val -> assertEquals(1L, val))
+                    .verifyComplete();
+        StepVerifier.create(Mono.from(binary.getT2().apply(record(Collections.emptyMap()))))
+                    .assertNext(val -> assertEquals(2L, val))
+                    .verifyComplete();
+
+        Tuple2<Function<ReactorQLRecord, Publisher<?>>, Function<ReactorQLRecord, Publisher<?>>> function =
+                ValueMapFeature.createBinaryMapper(expression("eq(3,4)"), metadata);
+        StepVerifier.create(Mono.from(function.getT1().apply(record(Collections.emptyMap()))))
+                    .assertNext(val -> assertEquals(3L, val))
+                    .verifyComplete();
+        StepVerifier.create(Mono.from(function.getT2().apply(record(Collections.emptyMap()))))
+                    .assertNext(val -> assertEquals(4L, val))
+                    .verifyComplete();
+
+        Tuple2<Function<ReactorQLRecord, Publisher<?>>, Function<ReactorQLRecord, Publisher<?>>> wrapped =
+                ValueMapFeature.createBinaryMapper(new ExpressionList<>(expression("eq(5,6)")), metadata);
+        StepVerifier.create(Mono.from(wrapped.getT1().apply(record(Collections.emptyMap()))))
+                    .assertNext(val -> assertEquals(5L, val))
+                    .verifyComplete();
+        StepVerifier.create(Mono.from(wrapped.getT2().apply(record(Collections.emptyMap()))))
+                    .assertNext(val -> assertEquals(6L, val))
+                    .verifyComplete();
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> ValueMapFeature.createBinaryMapper(expression("eq(1)"), metadata));
+
+        ReactorQLContext context = ReactorQLContext.ofDatasource(name -> Flux.just(name == null ? "root" : name));
+
+        StepVerifier.create(FromFeature.createFromMapperByFrom(null, metadata).apply(context))
+                    .assertNext(record -> assertEquals("root", record.getRecord()))
+                    .verifyComplete();
+
+        StepVerifier.create(FromFeature.createFromMapperByFrom(select("select * from test").getFromItem(), metadata)
+                                       .apply(context))
+                    .assertNext(record -> assertEquals("test", record.getName()))
+                    .verifyComplete();
+
+        StepVerifier.create(FromFeature.createFromMapperByFrom(select("select * from (values (1,'a'),(2,'b')) v(id,name)").getFromItem(), metadata)
+                                       .apply(ReactorQLContext.ofDatasource(ignore -> Flux.empty())))
+                    .expectNextMatches(record -> ((Map<?, ?>) record.getRecord()).get("id").equals(1L))
+                    .expectNextMatches(record -> ((Map<?, ?>) record.getRecord()).get("name").equals("b"))
+                    .verifyComplete();
+
+        ParenthesedFromItem wrappedTable = new ParenthesedFromItem(new Table("test"));
+        StepVerifier.create(FromFeature.createFromMapperByFrom(wrappedTable, metadata).apply(context))
+                    .assertNext(record -> assertEquals("test", record.getName()))
+                    .verifyComplete();
+
+        ParenthesedSelect parenthesedSelect = new ParenthesedSelect();
+        parenthesedSelect.setSelect(select("select * from test"));
+        StepVerifier.create(FromFeature.createFromMapperByFrom(parenthesedSelect, metadata).apply(context))
+                    .assertNext(record -> assertEquals("test", record.getName()))
+                    .verifyComplete();
+    }
+
+    @Test
+    void shouldHandleAdditionalValueMapBranches() throws Exception {
+        ReactorQLMetadata metadata = metadata("select 1");
+        ReactorQLRecord record = record(Collections.emptyMap()).addRecord("payload", Arrays.asList("a", "b"));
+
+        StepVerifier.create(Mono.fromDirect(ValueMapFeature.createMapperNow(new NullValue(), metadata).apply(record)))
+                    .verifyComplete();
+
+        IntervalExpression interval = new IntervalExpression().withExpression(new LongValue(2));
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(interval, metadata).apply(record)))
+                    .assertNext(val -> assertEquals(2L, val))
+                    .verifyComplete();
+
+        ReactorQLRecord parameterRecord = record.copy();
+        parameterRecord.getContext().bind("p", 3).bind(0, 4);
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(new net.sf.jsqlparser.expression.JdbcNamedParameter("p"), metadata).apply(parameterRecord)))
+                    .assertNext(val -> assertEquals(3, val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(new net.sf.jsqlparser.expression.JdbcParameter(0, true, "?"), metadata).apply(parameterRecord)))
+                    .assertNext(val -> assertEquals(4, val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(new net.sf.jsqlparser.expression.NumericBind().withBindId(0), metadata).apply(parameterRecord)))
+                    .assertNext(val -> assertEquals(4, val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(expression("true"), metadata).apply(record)))
+                    .assertNext(val -> assertEquals(Boolean.TRUE, val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(expression("false"), metadata).apply(record)))
+                    .assertNext(val -> assertEquals(Boolean.FALSE, val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(new net.sf.jsqlparser.expression.BooleanValue(true), metadata).apply(record)))
+                    .assertNext(val -> assertEquals(Boolean.TRUE, val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(new net.sf.jsqlparser.expression.StringValue("jetlinks"), metadata).apply(record)))
+                    .assertNext(val -> assertEquals("jetlinks", val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(new net.sf.jsqlparser.expression.DoubleValue("1.5"), metadata).apply(record)))
+                    .assertNext(val -> assertEquals(1.5D, val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(new net.sf.jsqlparser.expression.HexValue("0x01"), metadata).apply(record)))
+                    .assertNext(val -> assertEquals("0x01", val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(new net.sf.jsqlparser.expression.SignedExpression('~', new LongValue(1)), metadata).apply(record)))
+                    .assertNext(val -> assertEquals(-2L, val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(new net.sf.jsqlparser.expression.ArrayExpression(column("payload"), new LongValue(1)), metadata).apply(record)))
+                    .assertNext(val -> assertEquals("b", val))
+                    .verifyComplete();
+
+        StepVerifier.create(Mono.from(ValueMapFeature.createMapperNow(expression("exists(select 1)"), metadata).apply(record)))
+                    .assertNext(val -> assertEquals(Boolean.FALSE, val))
+                    .verifyComplete();
+    }
+
+    private static DefaultReactorQLMetadata metadata(String sql) {
+        return new DefaultReactorQLMetadata(sql);
+    }
+
+    private static ReactorQLRecord record(Map<String, Object> row) {
+        return ReactorQLRecord.newRecord("this", row, ReactorQLContext.ofDatasource(ignore -> Flux.empty()));
+    }
+
+    private static net.sf.jsqlparser.expression.Function function(String text) throws Exception {
+        return (net.sf.jsqlparser.expression.Function) expression(text);
+    }
+
+    private static net.sf.jsqlparser.expression.Function functionWithoutParameters(String name) {
+        net.sf.jsqlparser.expression.Function function = new net.sf.jsqlparser.expression.Function();
+        function.setName(name);
+        return function;
+    }
+
+    private static Column column(String text) throws Exception {
+        return (Column) expression(text);
+    }
+
+    private static Expression expression(String text) throws Exception {
+        return CCJSqlParserUtil.parseExpression(text);
+    }
+
+    private static PlainSelect select(String sql) throws Exception {
+        Statement statement = CCJSqlParserUtil.parse(sql);
+        return (PlainSelect) ((Select) statement).getSelectBody();
+    }
+
+    private static int idOf(ReactorQLRecord record) {
+        return ((Number) ((Map<?, ?>) record.getRecord()).get("id")).intValue();
+    }
+}

--- a/src/test/java/org/jetlinks/reactor/ql/utils/ExpressionUtilsTest.java
+++ b/src/test/java/org/jetlinks/reactor/ql/utils/ExpressionUtilsTest.java
@@ -59,7 +59,7 @@ class ExpressionUtilsTest {
     void testNull() {
         assertNull(ExpressionUtils.getSimpleValue(new JdbcNamedParameter("arg")).orElse(null) );
         assertNull(ExpressionUtils.getSimpleValue(new NumericBind().withBindId(0)).orElse(null) );
-        assertNull(ExpressionUtils.getSimpleValue(new JdbcParameter(0,true)).orElse(null));
+        assertNull(ExpressionUtils.getSimpleValue(new JdbcParameter(0, true, "?")).orElse(null));
 
     }
     @Test
@@ -71,7 +71,7 @@ class ExpressionUtilsTest {
 
         assertEquals(ExpressionUtils.getSimpleValue(new JdbcNamedParameter("arg"), context).orElse(null), 1);
         assertEquals(ExpressionUtils.getSimpleValue(new NumericBind().withBindId(0), context).orElse(null), 1);
-        assertEquals(ExpressionUtils.getSimpleValue(new JdbcParameter(0,true), context).orElse(null), 1);
+        assertEquals(ExpressionUtils.getSimpleValue(new JdbcParameter(0, true, "?"), context).orElse(null), 1);
 
     }
 }


### PR DESCRIPTION
## 目的

- 升级 JSqlParser 到 5.3，并适配 5.x AST / API 变化
- 补充针对分支热点的测试，提升回归保护能力

## 核心变动

- 构建：升级 `jsqlparser` 到 `5.3`，并将编译基线调整到 Java 11
- 兼容：适配 `Select` / `ParenthesedSelect` / `Values` / `ParenthesedFromItem` 等 5.x 节点模型变化
- 映射：更新 `FromFeature`、`ValueMapFeature`、`PropertyMapFeature`、`FunctionMapFeature` 等关键分发与映射逻辑
- 测试：新增 `DefaultContextRecordTest`、`FeatureCoverageTest`，并同步修正已有测试用例

## 测试结果

- 命令：`JAVA_HOME=$(/usr/libexec/java_home -v 11) mvn test`
- 单元测试：173 passed, 0 failed, 0 skipped
- 覆盖率：instruction 92.04%, branch 79.52%, line 92.69%

## 风险与说明

- 影响范围：SQL 解析、from/value 映射、函数参数处理、测试基线
- 未覆盖项：分支覆盖率已提升但尚未达到 80%，仍可继续围绕 `FromFeature` / `ValueMapFeature` 的剩余分支补测
- 已知限制：本次同时引入 Java 11 作为编译运行基线，消费方需确认本地 JDK 版本
